### PR TITLE
fix for #61

### DIFF
--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -3508,17 +3508,21 @@ namespace MLLE
         {
             recentLevelsToolStripMenuItem.DropDownItems.Clear();
             recentLevelsToolStripMenuItem.Enabled = RecentlyLoadedLevels.Count > 0;
+            _suspendEvent.Reset();
             for (int i = 0; i < RecentlyLoadedLevels.Count; ++i)
             {
                 string recentLevel = RecentlyLoadedLevels[i];
 
                 var toolStripItem = new ToolStripMenuItem((i + 1).ToString() + " " + Path.GetFileName(recentLevel));
                 toolStripItem.Click += (s, ee) => {
-                    LoadJ2L(recentLevel);
-                };
-
+                    if (PromptForSaving()) {
+                        DeleteLevelScriptIfEmpty();
+                        LoadJ2L(recentLevel);
+                    }
+                };                
                 recentLevelsToolStripMenuItem.DropDownItems.Add(toolStripItem);
             }
+            _suspendEvent.Set();
         }
         
         private void defineSmartTilesToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Call PromptForSaving method prior to loading level from recent level menu item.  Suspend events needed to update layers.  May be a short delay, but this should fix bug 61.

Also, recommend a refactor at some point of the load recent level logic and open level logic to a shared method, as the logic looks very similar at first glance