### PR TITLE
Two small fixes

### DIFF
--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -2928,16 +2928,19 @@ namespace MLLE
                     LastFocusedZone = FocusedZone.Tileset;
                     TilesetScrollbar.Focus();
                     LevelDisplay.ContextMenuStrip = TContextMenu;
+
+                    int mouseY = e.Y >= 0 ? e.Y : 0;
+
                     if (CurrentTilesetOverlay != TilesetOverlay.SmartTiles)
                     {
                         MouseTileX = e.X / 32;
-                        MouseTileY = (e.Y + TilesetScrollbar.Value - TilesetScrollbar.Minimum) / 32;
+                        MouseTileY = (mouseY + TilesetScrollbar.Value - TilesetScrollbar.Minimum) / 32;
                         MouseTile = MouseTileX + MouseTileY * 10;
                     }
                     else
                     {
                         MouseTileX = Math.Min(2, e.X / 106);
-                        MouseTileY = (e.Y + TilesetScrollbar.Value - TilesetScrollbar.Minimum) / 106;
+                        MouseTileY = (mouseY + TilesetScrollbar.Value - TilesetScrollbar.Minimum) / 106;
                         MouseTile = MouseTileX + MouseTileY * 3;
                     }
                     HoveringOverAnimationAreaOfTilesetPane = J2L.HasTiles && MouseTile >= J2L.TileCount;

--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -563,7 +563,10 @@ namespace MLLE
             if (DrawThread != null)
                 DrawThread.Abort();
 
-            DeleteLevelScriptIfEmpty();
+            if (J2L != null)
+            {
+                DeleteLevelScriptIfEmpty();
+            }
             
             bool windowIsMaximized = this.WindowState == FormWindowState.Maximized;
             Settings.IniWriteValue("Window", "Maximized", windowIsMaximized.ToString());

--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -564,9 +564,7 @@ namespace MLLE
                 DrawThread.Abort();
 
             if (J2L != null)
-            {
                 DeleteLevelScriptIfEmpty();
-            }
             
             bool windowIsMaximized = this.WindowState == FormWindowState.Maximized;
             Settings.IniWriteValue("Window", "Maximized", windowIsMaximized.ToString());

--- a/README.md
+++ b/README.md
@@ -11,28 +11,28 @@ Installation instructions:
 * If you already have a previous release of MLLE installed, you should not re-extract any of the .ini files, for risk of losing your personal settings.
 
 There’s no help file, because help files are hard, but here are some hotkeys:
-1-8: View that layer.
-Ctrl + 1-8: Edit layer properties for that layer.
-Ctrl + plus/minus: Zoom in/out.
-Ctrl + M: Toggle mask mode.
-M: View partial mask.
-Ctrl + P: Toggle parallax mode.
-P: View partial parallax.
-Ctrl + V: Toggle event view.
-Ctrl + Shift + R: Save & Run, with the start position temporarily moved to wherever your mouse is.
-F, Backspace, E, Ctrl + E, Shift + E: You know how these things work.
-I: Flip tiles vertically (available only for JJ2+ levels)
-Comma: Copy current tile.
-Shift + Comma: Copy current tile and the event on it.
-B: Begin or end a selection of tiles to grab.
-Delete: Clear layer/selection.
-Ctrl + C: Copy current selection.
-Ctrl + X: Copy and delete current selection.
-Ctrl + D: Deselect all.
-Ctrl + Z, Ctrl + Y: Undo, Redo.
-For editing tileset:
-Shift + T: Assign tile transparent tiletype.
-Shift + 0-9: Assign tile that tiletype, if possible. (e.g. 1 for Transparent and 4 for Caption in regular JJ2 levels.)
+* 1-8: View that layer.
+* Ctrl + 1-8: Edit layer properties for that layer.
+* Ctrl + plus/minus: Zoom in/out.
+* Ctrl + M: Toggle mask mode.
+* M: View partial mask.
+* Ctrl + P: Toggle parallax mode.
+* P: View partial parallax.
+* Ctrl + V: Toggle event view.
+* Ctrl + Shift + R: Save & Run, with the start position temporarily moved to wherever your mouse is.
+* F, Backspace, E, Ctrl + E, Shift + E: You know how these things work.
+* I: Flip tiles vertically (available only for JJ2+ levels)
+* Comma: Copy current tile.
+* Shift + Comma: Copy current tile and the event on it.
+* B: Begin or end a selection of tiles to grab.
+* Delete: Clear layer/selection.
+* Ctrl + C: Copy current selection.
+* Ctrl + X: Copy and delete current selection.
+* Ctrl + D: Deselect all.
+* Ctrl + Z, Ctrl + Y: Undo, Redo.
+* For editing tileset:
+* Shift + T: Assign tile transparent tiletype.
+* Shift + 0-9: Assign tile that tiletype, if possible. (e.g. 1 for Transparent and 4 for Caption in regular JJ2 levels.)
 Additionally, holding down the Control key while using either of the first two drawing tools (Paintbrush and Fill) triggers an alternate mode wherein they work somewhat differently. The Control key also serves as an eyedropper tool when you are redrawing tile images in JJ2+ levels.
 
 Building


### PR DESCRIPTION
Hi, I started trying out MLLE today and noticed two small things.

One is that if you start MLLE and immediately close it, it will crash because DeleteLevelScriptIfEmpty() references J2L, which could still be null. (Could also do this check inside DeleteLevelScriptIfEmpty() itself, but given the surrounding code and the semantics this seemed better, yeah?)

The other is that the help display is a bit hard to read currently, because Github and other Markdown renderers don't interpret line breaks unless you put two spaces at the end of a line, or a <br />. Instead of doing that I humbly suggest turning it into a list.