### PR TITLE
Warn user if chosen level filename is too long

### DIFF
--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -1875,7 +1875,11 @@ void main() {
                 DialogResult result = SaveJ2LDialog.ShowDialog();
                 _suspendEvent.Set();
                 if (result == DialogResult.OK)
+                {
+                    if (Path.GetFileName(SaveJ2LDialog.FileName).Length > 31 && MessageBox.Show("The filename you chose is too long and will crash the game.\r\nDo you want to pick a different filename?", "Filename too long", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+                        return AskUserForJ2LFilenameIfNecessary(alwaysNecessary);
                     return SaveJ2LDialog.FileName;
+                }
                 return null;
             }
             return J2L.FullFilePath;


### PR DESCRIPTION
Bit me just now, might as well help fellow noobs.
If you hate the inlining of the MessageBox, I'll gladly separate it into more lines. ;-)