### PR TITLE
Gracefully handle when the total tilecount exceeds the max tilecount

### DIFF
--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -1799,6 +1799,31 @@ void main() {
                     NewJ2L(); //dump whatever parts of the level had already been loaded prior to this error
                     return;
                 }
+
+                // Wanted to do this check in J2L.OpenLevel, but can't because LevelIsReadable might add more tilesets.
+                if (J2L.TileCount > J2L.MaxTiles)
+                {
+                    const string maxTilesErrorMessage = "The tileset(s) for this level contain too many tiles for this level. This can happen if the tilesets were edited after this level was saved.";
+                    if (J2L.VersionType == Version.JJ2 && J2L.Tilesets.Count == 1 && J2L.Tilesets[0].VersionType == Version.TSF)
+                    {
+                        // We might be able to get the user out of this mess
+                        DialogResult result = MessageBox.Show(maxTilesErrorMessage + "\r\n\r\nWould you like to convert the level to the newer 1.24 (The Secret Files) format to try to fix this? Older clients that do not have Plus will not be able to play the level after conversion.", "Problem loading level", MessageBoxButtons.YesNo, MessageBoxIcon.Hand);
+                        if (result == DialogResult.Yes)
+                        {
+                            J2L.ChangeVersion(Version.TSF);
+                        }
+                        else
+                        {
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        MessageBox.Show(maxTilesErrorMessage, "This level cannot be loaded", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+                        return;
+                    }
+                }
+
                 //EventsFromIni = TexturedJ2L.ReadEventIni("MLLEProfile.ini");
                 //TexturedJ2L.GenerateEventNameTextures(ref eventtexturenumberlist, EventsFromIni);
                 //J2L = TentativeJ2L;

--- a/Mainframe.cs
+++ b/Mainframe.cs
@@ -1804,24 +1804,22 @@ void main() {
                 if (J2L.TileCount > J2L.MaxTiles)
                 {
                     const string maxTilesErrorMessage = "The tileset(s) for this level contain too many tiles for this level. This can happen if the tilesets were edited after this level was saved.";
-                    if (J2L.VersionType == Version.JJ2 && J2L.Tilesets.Count == 1 && J2L.Tilesets[0].VersionType == Version.TSF)
+                    bool canAttemptConversion = J2L.VersionType == Version.JJ2 && J2L.Tilesets.Count == 1 && J2L.Tilesets[0].VersionType == Version.TSF;
+                    if (!canAttemptConversion)
                     {
-                        // We might be able to get the user out of this mess
-                        DialogResult result = MessageBox.Show(maxTilesErrorMessage + "\r\n\r\nWould you like to convert the level to the newer 1.24 (The Secret Files) format to try to fix this? Older clients that do not have Plus will not be able to play the level after conversion.", "Problem loading level", MessageBoxButtons.YesNo, MessageBoxIcon.Hand);
-                        if (result == DialogResult.Yes)
-                        {
-                            J2L.ChangeVersion(Version.TSF);
-                        }
-                        else
-                        {
-                            return;
-                        }
-                    }
-                    else
-                    {
+                        // We don't have enough context to solve this for the user (and this case will probably be even more rare than the other one)
                         MessageBox.Show(maxTilesErrorMessage, "This level cannot be loaded", MessageBoxButtons.OK, MessageBoxIcon.Hand);
+                        NewJ2L(); //dump whatever parts of the level had already been loaded prior to this error
                         return;
                     }
+                    // We might be able to get the user out of this mess
+                    DialogResult result = MessageBox.Show(maxTilesErrorMessage + "\r\n\r\nWould you like to convert the level to the newer 1.24 (The Secret Files) format to try to fix this? Older clients that do not have Plus will not be able to play the level after conversion.", "Problem loading level", MessageBoxButtons.YesNo, MessageBoxIcon.Hand);
+                    if (result != DialogResult.Yes)
+                    {
+                        NewJ2L(); //dump whatever parts of the level had already been loaded prior to this error
+                        return;
+                    }
+                    J2L.ChangeVersion(Version.TSF);
                 }
 
                 //EventsFromIni = TexturedJ2L.ReadEventIni("MLLEProfile.ini");


### PR DESCRIPTION
E.g. if a tileset was edited after the level was saved.
In the specific scenario that a tileset was extended past 1.23 limits and became TSF but the level is still 1.23, offer the user a solution to convert the level to TSF too.

![afbeelding](https://user-images.githubusercontent.com/2829264/144425707-8634326a-feb5-472d-84a3-a50b31c9aa14.png)

Solves this error encountered by Lynx, who locked themself out of their level after adding some tiles to their tileset: https://discord.com/channels/171303828937768960/171304641970044928/915910080308862976

As always, happy to change anything around text- or code-wise that you feel could be better.